### PR TITLE
Fix cache dir path, atomically create dirs and set ownership

### DIFF
--- a/src/main/java/io/vertx/core/file/FileSystemOptions.java
+++ b/src/main/java/io/vertx/core/file/FileSystemOptions.java
@@ -15,8 +15,6 @@ package io.vertx.core.file;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
 
-import java.io.File;
-
 import static io.vertx.core.file.impl.FileResolver.*;
 
 /**
@@ -40,13 +38,12 @@ public class FileSystemOptions {
   // get the system default temp dir location (can be overriden by using the standard java system property)
   // if not present default to the process start CWD
   private static final String TMPDIR = System.getProperty("java.io.tmpdir", ".");
-  private static final String DEFAULT_CACHE_DIR_BASE = "vertx-cache";
 
   /**
    * The default file caching dir. If the system property {@code "vertx.cacheDirBase"} is set, then this is the value
-   * If not, then the system property {@code java.io.tmpdir} is taken or {code .} if not set. suffixed with {@code vertx-cache}.
+   * If not, then the system property {@code java.io.tmpdir} is taken or {code .} if not set.
    */
-  public static final String DEFAULT_FILE_CACHING_DIR = System.getProperty(CACHE_DIR_BASE_PROP_NAME, TMPDIR + File.separator + DEFAULT_CACHE_DIR_BASE);
+  public static final String DEFAULT_FILE_CACHING_DIR = System.getProperty(CACHE_DIR_BASE_PROP_NAME, TMPDIR);
 
   private boolean classPathResolvingEnabled = DEFAULT_CLASS_PATH_RESOLVING_ENABLED;
   private boolean fileCachingEnabled = DEFAULT_FILE_CACHING_ENABLED;

--- a/src/main/java/io/vertx/core/file/impl/FileResolver.java
+++ b/src/main/java/io/vertx/core/file/impl/FileResolver.java
@@ -19,13 +19,17 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Enumeration;
-import java.util.UUID;
+import java.util.Set;
 import java.util.function.IntPredicate;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
@@ -92,7 +96,7 @@ public class FileResolver {
   private Thread shutdownHook;
   private final boolean enableCaching;
   private final boolean enableCpResolving;
-  private final String fileCacheDir;
+  private final String cacheDirBaseName;
 
   public FileResolver() {
     this(new FileSystemOptions());
@@ -101,7 +105,7 @@ public class FileResolver {
   public FileResolver(FileSystemOptions fileSystemOptions) {
     this.enableCaching = fileSystemOptions.isFileCachingEnabled();
     this.enableCpResolving = fileSystemOptions.isClassPathResolvingEnabled();
-    this.fileCacheDir = fileSystemOptions.getFileCacheDir();
+    this.cacheDirBaseName = fileSystemOptions.getFileCacheDir();
 
     String cwdOverride = System.getProperty("vertx.cwd");
     if (cwdOverride != null) {
@@ -110,7 +114,7 @@ public class FileResolver {
       cwd = null;
     }
     if (this.enableCpResolving) {
-      setupCacheDir(UUID.randomUUID().toString());
+      setupCacheDir();
     }
   }
 
@@ -375,11 +379,16 @@ public class FileResolver {
     return cl;
   }
 
-  private synchronized void setupCacheDir(String id) {
-    String cacheDirName = fileCacheDir + "/file-cache-" + id;
-    cacheDir = new File(cacheDirName);
-    if (!cacheDir.mkdirs()) {
-      throw new IllegalStateException("Failed to create cache dir: " + cacheDirName);
+  private synchronized void setupCacheDir() {
+    FileAttribute<Set<PosixFilePermission>> ownerPermissions =
+        PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------"));
+
+    try {
+      Path cacheDirBase = new File(cacheDirBaseName).toPath();
+      Files.createDirectories(cacheDirBase, ownerPermissions);
+      cacheDir = Files.createTempDirectory(cacheDirBase, "vertx-cache-", ownerPermissions).toFile();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e.getMessage() + ": " + cacheDirBaseName, e);
     }
     // Add shutdown hook to delete on exit
     shutdownHook = new Thread(() -> {

--- a/src/test/java/io/vertx/core/file/FileResolverTestBase.java
+++ b/src/test/java/io/vertx/core/file/FileResolverTestBase.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
  */
 public abstract class FileResolverTestBase extends VertxTestBase {
 
-  private final String cacheBaseDir = new File(System.getProperty("java.io.tmpdir", ".") + File.separator + "vertx-cache").getAbsolutePath();
+  private final String cacheBaseDir = new File(System.getProperty("java.io.tmpdir", ".")).getAbsolutePath();
 
   protected FileResolver resolver;
 
@@ -96,7 +96,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     for (int i = 0; i < 2; i++) {
       File file = resolver.resolveFile("afile.html");
       assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
+      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "vertx-cache-"));
       assertFalse(file.isDirectory());
       assertEquals("<html><body>afile</body></html>", readFile(file));
     }
@@ -109,7 +109,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
       for (int i = 0; i < 2; i++) {
         File file = vertx.resolveFile("afile.html");
         assertTrue(file.exists());
-        assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
+        assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "vertx-cache-"));
         assertFalse(file.isDirectory());
         assertEquals("<html><body>afile</body></html>", readFile(file));
       }
@@ -123,7 +123,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     for (int i = 0; i < 2; i++) {
       File file = resolver.resolveFile("afile with spaces.html");
       assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
+      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "vertx-cache-"));
       assertFalse(file.isDirectory());
       assertEquals("<html><body>afile with spaces</body></html>", readFile(file));
     }
@@ -134,7 +134,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     for (int i = 0; i < 2; i++) {
       File file = resolver.resolveFile(webRoot);
       assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
+      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "vertx-cache-"));
       assertTrue(file.isDirectory());
     }
   }
@@ -144,7 +144,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     for (int i = 0; i < 2; i++) {
       File file = resolver.resolveFile(webRoot + "/somefile.html");
       assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
+      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "vertx-cache-"));
       assertFalse(file.isDirectory());
       assertEquals("<html><body>blah</body></html>", readFile(file));
     }
@@ -155,7 +155,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     for (int i = 0; i < 2; i++) {
       File file = resolver.resolveFile(webRoot + "/subdir");
       assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
+      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "vertx-cache-"));
       assertTrue(file.isDirectory());
     }
   }
@@ -165,7 +165,7 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     for (int i = 0; i < 2; i++) {
       File file = resolver.resolveFile(webRoot + "/subdir/subfile.html");
       assertTrue(file.exists());
-      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "file-cache-"));
+      assertTrue(file.getPath().startsWith(cacheBaseDir + File.separator + "vertx-cache-"));
       assertFalse(file.isDirectory());
       assertEquals("<html><body>subfile</body></html>", readFile(file));
     }


### PR DESCRIPTION
On a multi-user system the first user that runs Vert.x
creates /tmp/vertx-cache/ and owns this directory and
prevents all other users from using it.

Solution:

Replace
/tmp/vertx-cache/file-cache-xxxxx/
by
/tmp/vertx-cache-xxxxx/

To prevent any race conditions use Files.createTempDirectory.

The "vertx.cacheDirBase" configuration option works as before: If
the directory doesn't exist it is created. Files.createDirectories
is used to prevent race conditions.

For security the directory permissions are restricted to the user
atomically when they are created.

Resolves #3510